### PR TITLE
Fix empty column, was shifting the column values

### DIFF
--- a/CSwiftV.xcodeproj/xcshareddata/xcschemes/CSwiftVIOS.xcscheme
+++ b/CSwiftV.xcodeproj/xcshareddata/xcschemes/CSwiftVIOS.xcscheme
@@ -38,6 +38,26 @@
                ReferencedContainer = "container:CSwiftV.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "18B665021AF7BC4B009D5195"
+               BuildableName = "CSwiftVOSXTests.xctest"
+               BlueprintName = "CSwiftVOSXTests"
+               ReferencedContainer = "container:CSwiftV.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1878D43B19B27FB800FF84A7"
+               BuildableName = "CSwiftVTests.xctest"
+               BlueprintName = "CSwiftVTests"
+               ReferencedContainer = "container:CSwiftV.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference

--- a/CSwiftV/CSwiftV.swift
+++ b/CSwiftV/CSwiftV.swift
@@ -44,9 +44,12 @@ public class CSwiftV {
         let keysAndRows = self.rows.map { (field :[String]) -> [String:String] in
 
             var row = [String:String]()
-
+            
             for (index, value) in field.enumerate() {
-                row[tempHeaders[index]] = value
+                //only store value which are not empty
+                if let v: String? = .Some(value) where value.isNotEmptyOrWhitespace() {
+                    row[tempHeaders[index]] = v
+                }
             }
 
             return row

--- a/CSwiftV/CSwiftV.swift
+++ b/CSwiftV/CSwiftV.swift
@@ -32,11 +32,10 @@ public class CSwiftV {
     public let rows: [[String]]
 
     public init(String string: String, separator:String = ",", headers:[String]? = nil) {
-
         var parsedLines = recordsFromString(string.stringByReplacingOccurrencesOfString("\r\n", withString: "\n")).map { cellsFromString($0, separator: separator) }
 
-        let tempHeaders = headers ?? parsedLines[0]
-
+        let tempHeaders = headers ?? parsedLines.removeFirst()
+        
         self.rows = parsedLines
 
         self.columnCount = tempHeaders.count
@@ -79,9 +78,7 @@ func cellsFromString(rowString:String, separator: String = ",") -> [String] {
 }
 
 func recordsFromString(string: String) -> [String] {
-
     return split("\n", string: string).filter { (string) -> Bool in return string.isNotEmptyOrWhitespace() }
-
 }
 
 func split(separator: String, string: String) -> [String] {

--- a/CSwiftV/CSwiftV.swift
+++ b/CSwiftV/CSwiftV.swift
@@ -8,6 +8,21 @@
 
 import Foundation
 
+extension String {
+    func isEmptyOrWhitespace() -> Bool {
+        
+        if(self.isEmpty) {
+            return true
+        }
+        
+        return (self.stringByTrimmingCharactersInSet(NSCharacterSet.whitespaceCharacterSet()) == "")
+    }
+    
+    func isNotEmptyOrWhitespace() -> Bool {
+        return !isEmptyOrWhitespace()
+    }
+}
+
 //MARK: Parser
 public class CSwiftV {
 
@@ -62,7 +77,7 @@ func cellsFromString(rowString:String, separator: String = ",") -> [String] {
 
 func recordsFromString(string: String) -> [String] {
 
-    return split("\n", string: string)
+    return split("\n", string: string).filter { (string) -> Bool in return string.isNotEmptyOrWhitespace() }
 
 }
 
@@ -74,7 +89,7 @@ func split(separator: String, string: String) -> [String] {
         return string.componentsSeparatedByString("\"").count % 2 == 0
     }
 
-    let merged = initial.reduce([]) { (prevArray, newString) -> [String] in
+    return initial.reduce([]) { (prevArray, newString) -> [String] in
 
         if let record = prevArray.last {
             if (oddNumberOfQuotes(record)) {
@@ -91,11 +106,4 @@ func split(separator: String, string: String) -> [String] {
         }
 
     }
-
-    let final = merged
-        .filter { (string) -> Bool in return string.characters.count > 0 }
-    
-    
-    return final
-
 }

--- a/CSwiftVTests/CSwiftVTests.swift
+++ b/CSwiftVTests/CSwiftVTests.swift
@@ -11,6 +11,9 @@ import XCTest
 
 import CSwiftV
 
+public let emptyColumns = "Year,Make,Model,Description,Price\r\n1997,Ford,,descrition,3000.00\r\n1999,Chevy,Venture,another description,\r\n"
+
+
 public let newLineSeparation = "Year,Make,Model,Description,Price\r\n1997,Ford,E350,descrition,3000.00\r\n1999,Chevy,Venture,another description,4900.00\r\n"
 
 public let newLineSeparationNoCR = "Year,Make,Model,Description,Price\n1997,Ford,E350,descrition,3000.00\n1999,Chevy,Venture,another description,4900.00\n"
@@ -289,6 +292,28 @@ class CSwiftVTests: XCTestCase {
         ]
 
         XCTAssertEqual(arrayUnderTest, expectedArray)
+    }
+
+    func testWhenCellsAreEmpty() {
+        
+        testString = emptyColumns
+        let csv = CSwiftV(String: testString)
+        
+        let expectedArray = [
+            ["1997","Ford","","descrition","3000.00"],
+            ["1997","Ford","","descrition","3000.00"],
+            ["1999","Chevy","Venture","another description",""]
+        ]
+        
+        XCTAssertEqual(csv.rows, expectedArray)
+        
+        let expectedKeyedRows = [
+            ["Year":"Year", "Make": "Make", "Description":"Description", "Price":"Price"],
+            ["Year":"1997", "Make": "Ford", "Description":"descrition", "Price":"3000.00"],
+            ["Year":"1999", "Make": "Chevy", "Model":"Venture", "Description":"another description"]
+        ]
+        
+        XCTAssertEqual(csv.keyedRows!, expectedKeyedRows)
     }
 
     

--- a/CSwiftVTests/CSwiftVTests.swift
+++ b/CSwiftVTests/CSwiftVTests.swift
@@ -301,14 +301,12 @@ class CSwiftVTests: XCTestCase {
         
         let expectedArray = [
             ["1997","Ford","","descrition","3000.00"],
-            ["1997","Ford","","descrition","3000.00"],
             ["1999","Chevy","Venture","another description",""]
         ]
         
         XCTAssertEqual(csv.rows, expectedArray)
         
         let expectedKeyedRows = [
-            ["Year":"Year", "Make": "Make", "Description":"Description", "Price":"Price"],
             ["Year":"1997", "Make": "Ford", "Description":"descrition", "Price":"3000.00"],
             ["Year":"1999", "Make": "Chevy", "Model":"Venture", "Description":"another description"]
         ]


### PR DESCRIPTION
Currently every line or cell with empty value are skipped.
But im my case that what causing an issue !

```
id,timestamp,battery 
297699, ,95
297700,1448387879000,95
```

when i was accessing the value timestamp was having the value of `95`, when it should be empty
