### PR TITLE
Updated to Swift 3.0 for Xcode 8 Beta 2

### DIFF
--- a/CSwiftV.xcodeproj/project.pbxproj
+++ b/CSwiftV.xcodeproj/project.pbxproj
@@ -301,26 +301,32 @@
 			attributes = {
 				LastSwiftMigration = 0720;
 				LastSwiftUpdateCheck = 0730;
-				LastUpgradeCheck = 0730;
+				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = ManyThings;
 				TargetAttributes = {
 					18B664F81AF7BC4B009D5195 = {
 						CreatedOnToolsVersion = 6.3.1;
+						LastSwiftMigration = 0800;
 					};
 					18B665021AF7BC4B009D5195 = {
 						CreatedOnToolsVersion = 6.3.1;
+						LastSwiftMigration = 0800;
 					};
 					6E8818101CE274A300912B26 = {
 						CreatedOnToolsVersion = 7.3.1;
+						LastSwiftMigration = 0800;
 					};
 					6E8818191CE274A300912B26 = {
 						CreatedOnToolsVersion = 7.3.1;
+						LastSwiftMigration = 0800;
 					};
 					95B468FF1CE1DAD8009FF983 = {
 						CreatedOnToolsVersion = 7.3.1;
+						LastSwiftMigration = 0800;
 					};
 					95B469081CE1DAD9009FF983 = {
 						CreatedOnToolsVersion = 7.3.1;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -483,6 +489,7 @@
 				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -525,6 +532,7 @@
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
@@ -566,6 +574,7 @@
 				PRODUCT_MODULE_NAME = CSwiftV;
 				PRODUCT_NAME = CSwiftV;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -596,6 +605,8 @@
 				PRODUCT_MODULE_NAME = CSwiftV;
 				PRODUCT_NAME = CSwiftV;
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -623,6 +634,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.manythings.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -644,6 +656,8 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.manythings.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -666,6 +680,7 @@
 				PRODUCT_NAME = CSwiftV;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.2;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -692,6 +707,8 @@
 				PRODUCT_NAME = CSwiftV;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.2;
 				VALIDATE_PRODUCT = YES;
@@ -711,6 +728,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = io.manythings.CswiftVTVOSTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
+				SWIFT_VERSION = 3.0;
 				TVOS_DEPLOYMENT_TARGET = 9.2;
 			};
 			name = Debug;
@@ -726,6 +744,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = io.manythings.CswiftVTVOSTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 				TVOS_DEPLOYMENT_TARGET = 9.2;
 				VALIDATE_PRODUCT = YES;
 			};
@@ -752,6 +772,7 @@
 				PRODUCT_NAME = CSwiftV;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -779,6 +800,8 @@
 				PRODUCT_NAME = CSwiftV;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -799,6 +822,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = io.manythings.CSwiftVIOSTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -815,6 +839,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = io.manythings.CSwiftVIOSTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;

--- a/CSwiftV.xcodeproj/xcshareddata/xcschemes/CSwiftVIOS.xcscheme
+++ b/CSwiftV.xcodeproj/xcshareddata/xcschemes/CSwiftVIOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0730"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/CSwiftV.xcodeproj/xcshareddata/xcschemes/CSwiftVOSX.xcscheme
+++ b/CSwiftV.xcodeproj/xcshareddata/xcschemes/CSwiftVOSX.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0730"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/CSwiftV.xcodeproj/xcshareddata/xcschemes/CswiftVTVOS.xcscheme
+++ b/CSwiftV.xcodeproj/xcshareddata/xcschemes/CswiftVTVOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0730"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "6E8818101CE274A300912B26"
-               BuildableName = "CswiftVTVOS.framework"
+               BuildableName = "CSwiftV.framework"
                BlueprintName = "CswiftVTVOS"
                ReferencedContainer = "container:CSwiftV.xcodeproj">
             </BuildableReference>
@@ -43,7 +43,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "6E8818101CE274A300912B26"
-            BuildableName = "CswiftVTVOS.framework"
+            BuildableName = "CSwiftV.framework"
             BlueprintName = "CswiftVTVOS"
             ReferencedContainer = "container:CSwiftV.xcodeproj">
          </BuildableReference>
@@ -65,7 +65,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "6E8818101CE274A300912B26"
-            BuildableName = "CswiftVTVOS.framework"
+            BuildableName = "CSwiftV.framework"
             BlueprintName = "CswiftVTVOS"
             ReferencedContainer = "container:CSwiftV.xcodeproj">
          </BuildableReference>
@@ -83,7 +83,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "6E8818101CE274A300912B26"
-            BuildableName = "CswiftVTVOS.framework"
+            BuildableName = "CSwiftV.framework"
             BlueprintName = "CswiftVTVOS"
             ReferencedContainer = "container:CSwiftV.xcodeproj">
          </BuildableReference>

--- a/Sources/CSwiftV.swift
+++ b/Sources/CSwiftV.swift
@@ -11,7 +11,7 @@ import class Foundation.NSCharacterSet
 extension String {
 
     var isEmptyOrWhitespace: Bool {
-        return isEmpty ? true : stringByTrimmingCharactersInSet(.whitespaceCharacterSet()) == ""
+        return isEmpty ? true : trimmingCharacters(in: .whitespaces) == ""
     }
 
     var isNotEmptyOrWhitespace: Bool {
@@ -29,7 +29,7 @@ public class CSwiftV {
     public let rows: [[String]]
 
     public init(string: String, separator: String = ",", headers: [String]? = nil) {
-        var parsedLines = CSwiftV.recordsFromString(string.stringByReplacingOccurrencesOfString("\r\n", withString: "\n")).map { CSwiftV.cellsFromString($0, separator: separator) }
+        var parsedLines = CSwiftV.recordsFromString(string.replacingOccurrences(of: "\r\n", with: "\n")).map { CSwiftV.cellsFromString($0, separator: separator) }
         self.headers = headers ?? parsedLines.removeFirst()
         rows = parsedLines
         columnCount = self.headers.count
@@ -38,7 +38,7 @@ public class CSwiftV {
         keyedRows = rows.map { field -> [String: String] in
             var row = [String: String]()
             //only store value which are not empty
-            for (index, value) in field.enumerate() where value.isNotEmptyOrWhitespace {
+            for (index, value) in field.enumerated() where value.isNotEmptyOrWhitespace {
                 row[tempHeaders[index]] = value
             }
             return row
@@ -49,27 +49,27 @@ public class CSwiftV {
         self.init(string: string, headers:headers, separator:",")
     }
 
-    internal static func cellsFromString(rowString: String, separator: String = ",") -> [String] {
+    internal static func cellsFromString(_ rowString: String, separator: String = ",") -> [String] {
         return CSwiftV.split(separator, string: rowString).map { element in
             if let first = element.characters.first, let last = element.characters.last where first == "\"" && last == "\"" {
-                let range = element.startIndex.successor() ..< element.endIndex.predecessor()
+                let range = element.characters.index(after: element.startIndex) ..< element.characters.index(before: element.endIndex)
                 return element[range]
             }
             return element
         }
     }
 
-    internal static func recordsFromString(string: String) -> [String] {
+    internal static func recordsFromString(_ string: String) -> [String] {
         return CSwiftV.split("\n", string: string).filter { $0.isNotEmptyOrWhitespace }
     }
 
-    private static func split(separator: String, string: String) -> [String] {
+    private static func split(_ separator: String, string: String) -> [String] {
 
-        func oddNumberOfQuotes(string: String) -> Bool {
-            return string.componentsSeparatedByString("\"").count % 2 == 0
+        func oddNumberOfQuotes(_ string: String) -> Bool {
+            return string.components(separatedBy: "\"").count % 2 == 0
         }
 
-        let initial = string.componentsSeparatedByString(separator)
+        let initial = string.components(separatedBy: separator)
         var merged = [String]()
         for newString in initial {
             guard let record = merged.last where oddNumberOfQuotes(record) == true else {

--- a/Sources/CSwiftV.swift
+++ b/Sources/CSwiftV.swift
@@ -46,12 +46,12 @@ public class CSwiftV {
     }
 
     public convenience init(string: String, headers: [String]?) {
-        self.init(string: string, headers:headers, separator:",")
+        self.init(string: string, separator:",", headers:headers)
     }
 
     internal static func cellsFromString(_ rowString: String, separator: String = ",") -> [String] {
         return CSwiftV.split(separator, string: rowString).map { element in
-            if let first = element.characters.first, let last = element.characters.last where first == "\"" && last == "\"" {
+            if let first = element.characters.first, let last = element.characters.last , first == "\"" && last == "\"" {
                 let range = element.characters.index(after: element.startIndex) ..< element.characters.index(before: element.endIndex)
                 return element[range]
             }
@@ -72,7 +72,7 @@ public class CSwiftV {
         let initial = string.components(separatedBy: separator)
         var merged = [String]()
         for newString in initial {
-            guard let record = merged.last where oddNumberOfQuotes(record) == true else {
+            guard let record = merged.last , oddNumberOfQuotes(record) == true else {
                 merged.append(newString)
                 continue
             }

--- a/Tests/CSwiftVTests.swift
+++ b/Tests/CSwiftVTests.swift
@@ -323,7 +323,7 @@ class CSwiftVTests: XCTestCase {
 
     func testPerformance() {
         let testString = nativeSwiftStringCSV
-        measureBlock {
+        measure {
             let _ = CSwiftV(string: testString)
         }
     }


### PR DESCRIPTION
So like PR #18 and #19, I too ran the migration tool to update the project and tests to Swift 3.0. I then fixed the bits that broke between Beta 1 and Beta 2 for use in my own project. I also upgraded the CSwiftV Xcode project to the new recommended settings, which means that whole module optimisation is now enabled for all targets. All tests are passing.

Since those two PRs exist already I'm not expecting this to be merged, but for anyone that is looking for a version that works with Swift 3.0 on Xcode 8 Beta 2, _perhaps_ you might consider to use my fork for the time being.
